### PR TITLE
Fixes error for too many slack users added to group

### DIFF
--- a/internal/clients/slack.go
+++ b/internal/clients/slack.go
@@ -150,7 +150,8 @@ func GetSlackUser(pdUsers []pagerduty.User) ([]slack.User, error) {
 	var ul []slack.User
 	linq.From(slackUserList).WhereT(func(u slack.User) bool {
 		return linq.From(pdUsers).WhereT(func(pU pagerduty.User) bool {
-			return strings.Compare(strings.ToLower(pU.Email), strings.ToLower(u.Profile.Email)) == 0 && !u.Deleted
+			//TODO: Proper handling of users who have no email set in PagerDuty. Also the case for inactive users
+			return strings.Compare(strings.ToLower(pU.Email), strings.ToLower(u.Profile.Email)) == 0 && !u.Deleted && pU.Email != ""
 		}).Count() > 0
 	}).SelectT(func(u slack.User) slack.User {
 		if log.GetLevel() == log.DebugLevel {


### PR DESCRIPTION
The PagerDuty API returns inactive users without their email set.
This lead to the issue that all slack users without an email set
were added to the slack handle the PD user was supposed to be
assigned to. Now all PD users without an email set are ignored.
